### PR TITLE
ci(deploy): fix error caused by backticks during deployment

### DIFF
--- a/.github/workflows/website_deploy.yml
+++ b/.github/workflows/website_deploy.yml
@@ -56,7 +56,7 @@ jobs:
               "model": "deepseek-chat",
               "messages": [
                 {"role": "system", "content": "You are a helpful assistant"},
-                {"role": "user", "content": "用中文回答，一句话总结以下更新内容，适合放在公告栏：${{ steps.changelog.outputs.added }}"}
+                {"role": "user", "content": "一句中文总结以下更新内容，适合放在公告栏（不允许出现“`”等特殊符号）：${{ steps.changelog.outputs.added }}"}
               ]
             }' | jq -r '.choices[0].message.content')
           echo "response<<EOF" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Deepseek included backticks (`) in the changelog summary, causing deployment failures. This issue has now been resolved.

---

集成（deploy）：修复部署过程中因反引号导致的错误

Deepseek 在总结更新内容时包含了反引号“`”，导致部署失败，现已修复该问题。