### PR TITLE
fix(circos): prevent type warning from type annotations

### DIFF
--- a/src/plotfig/circos.py
+++ b/src/plotfig/circos.py
@@ -8,6 +8,7 @@ import matplotlib.colors as mcolors
 import matplotlib.pyplot as plt
 from matplotlib.figure import Figure
 from matplotlib.projections.polar import PolarAxes
+from matplotlib.axes import Axes
 from pycirclize import Circos
 from loguru import logger
 
@@ -88,7 +89,7 @@ def _process_sym(
 
 def plot_circos_figure(
     connectome: NDArray,
-    ax: PolarAxes | None = None,
+    ax: Axes | None = None,
     symmetric: bool = True,
     node_names: list[str] | None = None,
     node_colors: list[str] | None = None,
@@ -229,5 +230,8 @@ def plot_circos_figure(
         fig = circos.plotfig()
         return fig
     else:
-        circos.plotfig(ax=ax)
-        return ax
+        if isinstance(ax, PolarAxes):
+            circos.plotfig(ax=ax)
+            return ax
+        else:
+            raise ValueError("ax 不是 PolarAxes 类型")


### PR DESCRIPTION
Add a check to ensure `ax` is a PolarAxes instance to avoid a TypeError.

---

修复(circos): 防止类型注释引发的警告

增加判断，确保 `ax` 为 PolarAxes 实例，避免抛出 TypeError。